### PR TITLE
Fix login error due to status check

### DIFF
--- a/src/pages/auth/LoginContainer.tsx
+++ b/src/pages/auth/LoginContainer.tsx
@@ -56,7 +56,7 @@ export default function LoginContainer() {
     
     const handleLogin = async () => {
         const res = await authServices.login(username, password);
-        if(res?.status === 'ACCEPTED'){
+        if(res?.status === 'OK'){
             const user = {username: username, role: res.role, token:res.token}
             console.log('user: ',user);
             dispatch(enqueueUser(user));


### PR DESCRIPTION
The login was failing due to a change in the status returned from the backend. Now when login, the backend returns a status OK not ACCEPTED.